### PR TITLE
Python3 compatibility

### DIFF
--- a/basalt/tasks/__init__.py
+++ b/basalt/tasks/__init__.py
@@ -1,10 +1,16 @@
-from dict_config_parser import DictConfigParser
-from config_generator import generate_config
-from config_generator import get_config_vars
-from fs_commands import mkdirp
-from simple_version import get_major_version
-from simple_version import get_minor_version
-from simple_version import get_minor_version_with_increment
-from package_generator import package
-from vcs_info import get_commit_rev
-from vcs_info import get_branch
+try:
+    # python 2.x
+    from dict_config_parser import DictConfigParser
+except ImportError:
+    # python 3.x
+    from configparser import ConfigParser
+
+from .config_generator import generate_config
+from .config_generator import get_config_vars
+from .fs_commands import mkdirp
+from .simple_version import get_major_version
+from .simple_version import get_minor_version
+from .simple_version import get_minor_version_with_increment
+from .package_generator import package
+from .vcs_info import get_commit_rev
+from .vcs_info import get_branch

--- a/basalt/tasks/config_generator.py
+++ b/basalt/tasks/config_generator.py
@@ -2,8 +2,8 @@ import os
 import sys
 import yaml
 
-from utils import print_err
-from fs_commands import mkdirp
+from .utils import print_err
+from .fs_commands import mkdirp
 from jinja2 import Template, Environment, FileSystemLoader
 
 env = Environment(loader=FileSystemLoader('templates'))
@@ -22,7 +22,7 @@ def generate_config(template_name, config, outputfile, section="build-vars"):
     """\
     Generates a config from a template and with values from the yaml config.
 
-    A section can optionally be passed if somthing else than 'build-vars' should be used. 
+    A section can optionally be passed if somthing else than 'build-vars' should be used.
     """
     config_vars = get_config_vars(config)
     script_template = env.get_template(template_name)

--- a/basalt/tasks/package_generator.py
+++ b/basalt/tasks/package_generator.py
@@ -57,15 +57,6 @@ def package(yaml_conf_file, injects=None, builder='fpm'):
                 # fpm_args.append(single_dash_parameter % ('d', dependency))
                 fpm_args.append("-d")
                 fpm_args.append(dependency)
-    if gen_config.has_key('conflicts'):
-        dependencies = gen_config.pop('conflicts')
-        if type(dependencies) is str:
-            fpm_args.append("--conflicts")
-            fpm_args.append(dependencies)
-        elif type(dependencies) is list:
-            for dependency in dependencies:
-                fpm_args.append("--conflicts")
-                fpm_args.append(dependency)
 
     for key, value in gen_config.items():
         param = ""

--- a/basalt/tasks/package_generator.py
+++ b/basalt/tasks/package_generator.py
@@ -57,6 +57,15 @@ def package(yaml_conf_file, injects=None, builder='fpm'):
                 # fpm_args.append(single_dash_parameter % ('d', dependency))
                 fpm_args.append("-d")
                 fpm_args.append(dependency)
+    if gen_config.has_key('conflicts'):
+        dependencies = gen_config.pop('conflicts')
+        if type(dependencies) is str:
+            fpm_args.append("--conflicts")
+            fpm_args.append(dependencies)
+        elif type(dependencies) is list:
+            for dependency in dependencies:
+                fpm_args.append("--conflicts")
+                fpm_args.append(dependency)
 
     for key, value in gen_config.items():
         param = ""


### PR DESCRIPTION
In Python 3 dict_config_parser has been renamed to configparser.
Switched to explicit imports, which are required now.

Fixes #7 